### PR TITLE
feat: DLQ API and transactional delete support

### DIFF
--- a/examples/count_methods.rs
+++ b/examples/count_methods.rs
@@ -10,7 +10,7 @@ use pgqrs::config::Config;
 use pgqrs::tables::pgqrs_messages::{NewMessage, PgqrsMessages};
 use pgqrs::tables::pgqrs_queues::{NewQueue, PgqrsQueues};
 use pgqrs::tables::pgqrs_workers::{NewWorker, PgqrsWorkers};
-use pgqrs::tables::{PgqrsArchiveTable, Table};
+use pgqrs::tables::{PgqrsArchive, Table};
 use pgqrs::PgqrsAdmin;
 use serde_json::json;
 
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let queues = PgqrsQueues::new(pool.clone());
     let workers = PgqrsWorkers::new(pool.clone());
     let messages = PgqrsMessages::new(pool.clone());
-    let archives = PgqrsArchiveTable::new(pool.clone());
+    let archives = PgqrsArchive::new(pool.clone());
 
     // Install the schema and create test data
     admin.install().await?;
@@ -143,49 +143,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n=== Count By Foreign Key ===");
 
     // Count workers by queue
-    let queue1_workers = workers.count_by_fk(queue1.id).await?;
-    let queue2_workers = workers.count_by_fk(queue2.id).await?;
-    println!(
-        "Workers in queue '{}': {}",
-        queue1.queue_name, queue1_workers
-    );
-    println!(
-        "Workers in queue '{}': {}",
-        queue2.queue_name, queue2_workers
-    );
+    {
+        let mut txn = pool.begin().await?;
+        let queue1_workers = workers.count_for_fk(queue1.id, &mut txn).await?;
+        let queue2_workers = workers.count_for_fk(queue2.id, &mut txn).await?;
+        println!(
+            "Workers in queue '{}': {}",
+            queue1.queue_name, queue1_workers
+        );
+        println!(
+            "Workers in queue '{}': {}",
+            queue2.queue_name, queue2_workers
+        );
 
-    // Count messages by queue
-    let queue1_messages = messages.count_by_fk(queue1.id).await?;
-    let queue2_messages = messages.count_by_fk(queue2.id).await?;
-    println!(
-        "Messages in queue '{}': {}",
-        queue1.queue_name, queue1_messages
-    );
-    println!(
-        "Messages in queue '{}': {}",
-        queue2.queue_name, queue2_messages
-    );
+        // Count messages by queue
+        let queue1_messages = messages.count_for_fk(queue1.id, &mut txn).await?;
+        let queue2_messages = messages.count_for_fk(queue2.id, &mut txn).await?;
+        println!(
+            "Messages in queue '{}': {}",
+            queue1.queue_name, queue1_messages
+        );
+        println!(
+            "Messages in queue '{}': {}",
+            queue2.queue_name, queue2_messages
+        );
 
-    // Count archived messages by queue
-    let queue1_archives = archives.count_by_fk(queue1.id).await?;
-    let queue2_archives = archives.count_by_fk(queue2.id).await?;
-    println!(
-        "Archived messages in queue '{}': {}",
-        queue1.queue_name, queue1_archives
-    );
-    println!(
-        "Archived messages in queue '{}': {}",
-        queue2.queue_name, queue2_archives
-    );
+        // Count archived messages by queue
+        let queue1_archives = archives.count_for_fk(queue1.id, &mut txn).await?;
+        let queue2_archives = archives.count_for_fk(queue2.id, &mut txn).await?;
+        println!(
+            "Archived messages in queue '{}': {}",
+            queue1.queue_name, queue1_archives
+        );
+        println!(
+            "Archived messages in queue '{}': {}",
+            queue2.queue_name, queue2_archives
+        );
+    }
 
-    // Queues don't have meaningful foreign keys, so this returns 0
-    let queue_foreign_count = queues.count_by_fk(999).await?;
-    println!("Queues by foreign key (always 0): {}", queue_foreign_count);
+    {
+        let mut txn = pool.begin().await?;
+        // Queues don't have meaningful foreign keys, so this returns 0
+        let queue_foreign_count = queues.count_for_fk(999, &mut txn).await?;
+        println!("Queues by foreign key (always 0): {}", queue_foreign_count);
+    }
 
     println!("\n=== Summary ===");
     println!("The Table trait now provides a unified interface for:");
     println!("- count(): Get total record count in any table");
-    println!("- count_by_fk(): Get count of records matching a foreign key");
+    println!("- count_for_fk(): Get count of records matching a foreign key");
     println!("- This enables consistent counting operations across all tables");
     println!("- Archive table is now included with full CRUD + count support");
 

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -9,7 +9,7 @@ pub mod pgqrs_queues;
 pub mod pgqrs_workers;
 pub mod table;
 
-pub use pgqrs_archive::{PgqrsArchive, PgqrsArchiveTable};
+pub use pgqrs_archive::PgqrsArchive;
 pub use pgqrs_messages::{NewMessage, PgqrsMessages};
 pub use pgqrs_queues::{NewQueue, PgqrsQueues};
 pub use pgqrs_workers::{NewWorker, PgqrsWorkers};

--- a/src/tables/pgqrs_queues.rs
+++ b/src/tables/pgqrs_queues.rs
@@ -260,7 +260,11 @@ impl Table for PgqrsQueues {
     ///
     /// # Returns
     /// Always returns 0 (queues have no foreign key relationships)
-    async fn count_by_fk(&self, _foreign_key_value: i64) -> Result<i64> {
+    async fn count_for_fk<'a, 'b: 'a>(
+        &self,
+        _foreign_key_value: i64,
+        _tx: &'a mut sqlx::Transaction<'b, sqlx::Postgres>,
+    ) -> Result<i64> {
         // Queues don't have foreign keys, so this always returns 0
         Ok(0)
     }
@@ -283,6 +287,22 @@ impl Table for PgqrsQueues {
             .rows_affected();
 
         Ok(rows_affected)
+    }
+
+    /// Delete queues by foreign key within a transaction.
+    ///
+    /// # Arguments
+    /// * `_foreign_key_value` - Ignored (queues have no foreign keys)
+    /// * `tx` - Mutable reference to an active SQL transaction
+    /// # Returns
+    /// Always returns 0 (queues have no foreign key relationships)
+    async fn delete_by_fk<'a, 'b: 'a>(
+        &self,
+        _foreign_key_value: i64,
+        _tx: &'a mut sqlx::Transaction<'b, sqlx::Postgres>,
+    ) -> Result<u64> {
+        // Queues don't have foreign keys, so this always returns 0
+        Ok(0)
     }
 }
 

--- a/src/tables/table.rs
+++ b/src/tables/table.rs
@@ -88,7 +88,11 @@ pub trait Table {
     ///
     /// # Returns
     /// Number of records matching the foreign key criteria
-    async fn count_by_fk(&self, foreign_key_value: i64) -> Result<i64>;
+    async fn count_for_fk<'a, 'b: 'a>(
+        &self,
+        foreign_key_value: i64,
+        tx: &'a mut sqlx::Transaction<'b, sqlx::Postgres>,
+    ) -> Result<i64>;
 
     /// Delete a record by ID.
     ///
@@ -98,4 +102,18 @@ pub trait Table {
     /// # Returns
     /// Number of rows affected (0 or 1)
     async fn delete(&self, id: i64) -> Result<u64>;
+
+    /// Delete records by foreign key within a transaction.
+    ///
+    /// # Arguments
+    /// * `foreign_key_value` - Value of the foreign key to filter by
+    /// * `tx` - Mutable reference to an active SQL transaction
+    ///
+    /// # Returns
+    /// Number of rows affected
+    async fn delete_by_fk<'a, 'b: 'a>(
+        &self,
+        foreign_key_value: i64,
+        tx: &'a mut sqlx::Transaction<'b, sqlx::Postgres>,
+    ) -> Result<u64>;
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -211,7 +211,7 @@ fn test_cli_archive_functionality() {
     assert_eq!(archived_message.original_msg_id, dequeued_message.id);
 
     let archived_list: Vec<ArchivedMessage> =
-        run_cli_command_json(&db_url, &["archive", "list", queue_name]);
+        run_cli_command_json(&db_url, &["archive", "list", "--queue", queue_name]);
     assert!(
         archived_list.len() == 1,
         "Expected 1 archived message, found {}",
@@ -220,7 +220,5 @@ fn test_cli_archive_functionality() {
 
     // Clean up
     run_cli_command_expect_success(&db_url, &["queue", "purge", queue_name]);
-    run_cli_command_expect_success(&db_url, &["archive", "delete", queue_name]);
-    run_cli_command_expect_success(&db_url, &["worker", "delete", &worker_id.to_string()]);
     run_cli_command_expect_success(&db_url, &["queue", "delete", queue_name]);
 }

--- a/tests/lib_pgbouncer_tests.rs
+++ b/tests/lib_pgbouncer_tests.rs
@@ -42,7 +42,7 @@ async fn test_pgbouncer_happy_path() {
     }
     let queue_info = queue_result.unwrap();
     let producer = Producer::new(admin.pool.clone(), &queue_info, &admin.config);
-    let consumer = Consumer::new(admin.pool.clone(), &queue_info);
+    let consumer = Consumer::new(admin.pool.clone(), &queue_info, &admin.config);
 
     // Send a message through PgBouncer
     let test_message = json!({

--- a/tests/worker_tests.rs
+++ b/tests/worker_tests.rs
@@ -89,7 +89,7 @@ async fn test_worker_message_assignment() {
     // Create a test queue
     let queue_info = admin.create_queue("message_queue").await.unwrap();
     let producer = pgqrs::Producer::new(admin.pool.clone(), &queue_info, &admin.config);
-    let consumer = Consumer::new(admin.pool.clone(), &queue_info);
+    let consumer = Consumer::new(admin.pool.clone(), &queue_info, &admin.config);
 
     // Register a worker to verify the worker registration process
     let worker = admin
@@ -260,7 +260,7 @@ async fn test_worker_deletion_with_references() {
     let queue_name = "test_worker_deletion_with_references";
     let queue_info = admin.create_queue(queue_name).await.unwrap();
     let producer = Producer::new(admin.pool.clone(), &queue_info, &admin.config);
-    let consumer = Consumer::new(admin.pool.clone(), &queue_info);
+    let consumer = Consumer::new(admin.pool.clone(), &queue_info, &admin.config);
 
     let worker = admin
         .register(queue_info.queue_name.clone(), "test-host".to_string(), 8080)
@@ -338,7 +338,7 @@ async fn test_worker_deletion_with_archived_references() {
     let queue_name = "test_worker_deletion_with_archived_references";
     let queue_info = admin.create_queue(queue_name).await.unwrap();
     let producer = Producer::new(admin.pool.clone(), &queue_info, &admin.config);
-    let consumer = Consumer::new(admin.pool.clone(), &queue_info);
+    let consumer = Consumer::new(admin.pool.clone(), &queue_info, &admin.config);
     let worker = admin
         .register(queue_info.queue_name.clone(), "test-host".to_string(), 8080)
         .await
@@ -381,7 +381,7 @@ async fn test_purge_old_workers_respects_references() {
     let queue_name = "test_purge_old_workers_with_references";
     let queue_info = admin.create_queue(queue_name).await.unwrap();
     let producer = Producer::new(admin.pool.clone(), &queue_info, &admin.config);
-    let consumer = Consumer::new(admin.pool.clone(), &queue_info);
+    let consumer = Consumer::new(admin.pool.clone(), &queue_info, &admin.config);
 
     // Register two workers
     let worker1 = admin


### PR DESCRIPTION
## Summary
- Implements Dead Letter Queue (DLQ) support using archive filters (no new table)
- Refactors Table trait to support transactional delete and count by foreign key
- Updates all Table trait implementors for new API
- Adds and updates tests for DLQ, archive, and transactional delete logic
- Cleans up code for idiomatic Rust and better separation of concerns

## Details
- DLQ is implemented as a filter on the archive table for messages exceeding max attempts
- Table trait now provides  and  for transactional safety
- All related tests updated to use new API and ensure referential integrity
- CLI and public API expose DLQ and archive management

## Motivation
- Fixes #18 (DLQ support)
- Ensures safe queue deletion and archive management
- Prepares codebase for future extensibility