### PR TITLE
refactor(worker): share worker table dialect transitions

### DIFF
--- a/crates/pgqrs/src/builders/admin.rs
+++ b/crates/pgqrs/src/builders/admin.rs
@@ -2,6 +2,7 @@
 
 use crate::error::Result;
 use crate::store::Store;
+use crate::tables::WorkerTable;
 use crate::types::QueueRecord;
 use crate::{QueueMetrics, SystemStats, WorkerHealthStats, WorkerStats};
 

--- a/crates/pgqrs/src/builders/tables.rs
+++ b/crates/pgqrs/src/builders/tables.rs
@@ -35,7 +35,7 @@ impl<'a, S: Store> TablesBuilder<'a, S> {
     }
 
     /// Access worker table operations
-    pub fn workers(self) -> &'a dyn crate::store::WorkerTable {
+    pub fn workers(self) -> &'a S::Workers {
         self.store.workers()
     }
 

--- a/crates/pgqrs/src/store/any.rs
+++ b/crates/pgqrs/src/store/any.rs
@@ -128,6 +128,8 @@ impl AnyStore {
 
 #[async_trait]
 impl Store for AnyStore {
+    type Workers = dyn WorkerTable;
+
     async fn execute_raw(&self, sql: &str) -> crate::error::Result<()> {
         match self {
             #[cfg(feature = "postgres")]
@@ -250,7 +252,7 @@ impl Store for AnyStore {
         }
     }
 
-    fn workers(&self) -> &dyn WorkerTable {
+    fn workers(&self) -> &Self::Workers {
         match self {
             #[cfg(feature = "postgres")]
             AnyStore::Postgres(s) => s.workers(),

--- a/crates/pgqrs/src/store/dialect.rs
+++ b/crates/pgqrs/src/store/dialect.rs
@@ -50,7 +50,13 @@ pub(crate) struct MessageSql {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct WorkerSql {
     pub mark_stopped: &'static str,
+    pub suspend: &'static str,
+    pub poll: &'static str,
+    pub interrupt: &'static str,
+    pub shutdown: &'static str,
     pub complete_poll: &'static str,
+    pub heartbeat: &'static str,
+    pub resume: &'static str,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/pgqrs/src/store/mod.rs
+++ b/crates/pgqrs/src/store/mod.rs
@@ -64,6 +64,8 @@ pub(crate) mod sqlite_utils {
 /// and transaction management.
 #[async_trait]
 pub trait Store: Send + Sync + 'static {
+    type Workers: WorkerTable + ?Sized;
+
     /// Execute raw SQL without parameters.
     async fn execute_raw(&self, sql: &str) -> crate::error::Result<()>;
 
@@ -93,7 +95,7 @@ pub trait Store: Send + Sync + 'static {
     /// Get access to the repositories.
     fn queues(&self) -> &dyn QueueTable;
     fn messages(&self) -> &dyn MessageTable;
-    fn workers(&self) -> &dyn WorkerTable;
+    fn workers(&self) -> &Self::Workers;
     fn db_state(&self) -> &dyn DbStateTable;
     fn workflows(&self) -> &dyn WorkflowTable;
     fn workflow_runs(&self) -> &dyn RunRecordTable;

--- a/crates/pgqrs/src/store/postgres/dialect.rs
+++ b/crates/pgqrs/src/store/postgres/dialect.rs
@@ -252,10 +252,45 @@ SET status = 'stopped',
     shutdown_at = NOW()
 WHERE id = $1
 "#,
+        suspend: r#"
+UPDATE pgqrs_workers
+SET status = 'suspended'
+WHERE id = $1 AND status IN ('ready', 'polling', 'interrupted')
+RETURNING id
+"#,
+        poll: r#"
+UPDATE pgqrs_workers
+SET status = 'polling'
+WHERE id = $1 AND status IN ('ready', 'polling')
+RETURNING id
+"#,
+        interrupt: r#"
+UPDATE pgqrs_workers
+SET status = 'interrupted'
+WHERE id = $1 AND status = 'polling'
+RETURNING id
+"#,
+        shutdown: r#"
+UPDATE pgqrs_workers
+SET status = 'stopped', shutdown_at = $2
+WHERE id = $1 AND status = 'suspended'
+RETURNING id
+"#,
         complete_poll: r#"
 UPDATE pgqrs_workers
 SET status = 'ready'
 WHERE id = $1 AND status = 'polling'
+RETURNING id
+"#,
+        heartbeat: r#"
+UPDATE pgqrs_workers
+SET heartbeat_at = $1
+WHERE id = $2
+"#,
+        resume: r#"
+UPDATE pgqrs_workers
+SET status = 'ready'
+WHERE id = $1 AND status = 'suspended'
 RETURNING id
 "#,
     };

--- a/crates/pgqrs/src/store/postgres/mod.rs
+++ b/crates/pgqrs/src/store/postgres/mod.rs
@@ -18,8 +18,8 @@ use self::tables::pgqrs_workers::Workers as PostgresWorkerTable;
 use self::tables::pgqrs_workflow_runs::RunRecords as PostgresRunRecordTable;
 use self::tables::pgqrs_workflow_steps::StepRecords as PostgresStepRecordTable;
 use self::tables::pgqrs_workflows::Workflows as PostgresWorkflowTable;
-
 use crate::config::Config;
+use crate::store::postgres::tables::Workers;
 
 pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("migrations/postgres");
 
@@ -59,6 +59,8 @@ impl PostgresStore {
 
 #[async_trait]
 impl Store for PostgresStore {
+    type Workers = Workers;
+
     async fn execute_raw(&self, sql: &str) -> crate::error::Result<()> {
         sqlx::raw_sql(sql).execute(&self.pool).await?;
         Ok(())
@@ -113,7 +115,7 @@ impl Store for PostgresStore {
         self.messages.as_ref()
     }
 
-    fn workers(&self) -> &dyn WorkerTable {
+    fn workers(&self) -> &Self::Workers {
         self.workers.as_ref()
     }
 

--- a/crates/pgqrs/src/store/postgres/tables/pgqrs_workers.rs
+++ b/crates/pgqrs/src/store/postgres/tables/pgqrs_workers.rs
@@ -6,10 +6,12 @@
 use crate::error::Result;
 use crate::store::dialect::SqlDialect;
 use crate::store::postgres::dialect::PostgresDialect;
+use crate::store::query::{QueryBuilder, QueryParam};
+use crate::store::tables::DialectWorkerTable;
 use crate::types::{WorkerRecord, WorkerStatus};
 use async_trait::async_trait;
 use chrono::Utc;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres};
 
 // SQL constants for worker table operations
 const INSERT_WORKER: &str = r#"
@@ -171,28 +173,6 @@ impl Workers {
         Ok(status)
     }
 
-    /// Update worker heartbeat timestamp.
-    pub async fn heartbeat(&self, worker_id: i64) -> Result<()> {
-        const UPDATE_HEARTBEAT: &str = r#"
-            UPDATE pgqrs_workers
-            SET heartbeat_at = $1
-            WHERE id = $2
-        "#;
-        let now = Utc::now();
-        sqlx::query(UPDATE_HEARTBEAT)
-            .bind(now)
-            .bind(worker_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "UPDATE_HEARTBEAT".into(),
-                source: Box::new(e),
-                context: format!("Failed to update heartbeat for worker {}", worker_id),
-            })?;
-
-        Ok(())
-    }
-
     /// Check if this worker is healthy based on heartbeat age
     pub async fn is_healthy(&self, worker_id: i64, max_age: chrono::Duration) -> Result<bool> {
         let threshold = Utc::now() - max_age;
@@ -213,183 +193,36 @@ impl Workers {
         Ok(is_healthy)
     }
 
-    /// Transition worker to Suspended.
-    pub async fn suspend(&self, worker_id: i64) -> Result<()> {
-        const TRANSITION_TO_SUSPENDED: &str = r#"
-            UPDATE pgqrs_workers
-            SET status = 'suspended'
-            WHERE id = $1 AND status IN ('ready', 'polling', 'interrupted')
-            RETURNING id
-        "#;
-        let result: Option<i64> = sqlx::query_scalar(TRANSITION_TO_SUSPENDED)
-            .bind(worker_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "TRANSITION_TO_SUSPENDED".into(),
-                source: Box::new(e),
-                context: format!("Failed to suspend worker {}", worker_id),
-            })?;
-
-        match result {
-            Some(_) => Ok(()),
-            None => {
-                let current_status = self.get_status(worker_id).await?;
-                Err(crate::error::Error::InvalidStateTransition {
-                    from: current_status.to_string(),
-                    to: "suspended".to_string(),
-                    reason: "Worker must be Ready, Polling, or Interrupted to suspend".to_string(),
-                })
-            }
+    fn bind_query<'a>(
+        mut builder: sqlx::query::Query<'a, Postgres, sqlx::postgres::PgArguments>,
+        query: &'a QueryBuilder,
+    ) -> sqlx::query::Query<'a, Postgres, sqlx::postgres::PgArguments> {
+        for param in query.params() {
+            builder = match param {
+                QueryParam::I64(value) => builder.bind(*value),
+                QueryParam::I32(value) => builder.bind(*value),
+                QueryParam::String(value) => builder.bind(value),
+                QueryParam::Json(value) => builder.bind(value),
+                QueryParam::DateTime(value) => builder.bind(*value),
+            };
         }
+        builder
     }
 
-    /// Transition worker from Suspended to Ready.
-    pub async fn resume(&self, worker_id: i64) -> Result<()> {
-        const TRANSITION_SUSPENDED_TO_READY: &str = r#"
-            UPDATE pgqrs_workers
-            SET status = 'ready'
-            WHERE id = $1 AND status = 'suspended'
-            RETURNING id
-        "#;
-        let result: Option<i64> = sqlx::query_scalar(TRANSITION_SUSPENDED_TO_READY)
-            .bind(worker_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: format!("TRANSITION_SUSPENDED_TO_READY ({})", worker_id),
-                source: Box::new(e),
-                context: format!("Failed to resume worker {}", worker_id),
-            })?;
-
-        match result {
-            Some(_) => Ok(()),
-            None => {
-                let current_status = self.get_status(worker_id).await?;
-                Err(crate::error::Error::InvalidStateTransition {
-                    from: current_status.to_string(),
-                    to: "ready".to_string(),
-                    reason: "Worker must be in Suspended state to resume".to_string(),
-                })
-            }
+    fn bind_returning_query<'a>(
+        mut builder: sqlx::query::QueryScalar<'a, Postgres, i64, sqlx::postgres::PgArguments>,
+        query: &'a QueryBuilder,
+    ) -> sqlx::query::QueryScalar<'a, Postgres, i64, sqlx::postgres::PgArguments> {
+        for param in query.params() {
+            builder = match param {
+                QueryParam::I64(value) => builder.bind(*value),
+                QueryParam::I32(value) => builder.bind(*value),
+                QueryParam::String(value) => builder.bind(value),
+                QueryParam::Json(value) => builder.bind(value),
+                QueryParam::DateTime(value) => builder.bind(*value),
+            };
         }
-    }
-
-    /// Transition worker from Polling to Ready.
-    pub async fn complete_poll(&self, worker_id: i64) -> Result<()> {
-        let result: Option<i64> = sqlx::query_scalar(PostgresDialect::WORKER.complete_poll)
-            .bind(worker_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "TRANSITION_POLLING_TO_READY".into(),
-                source: Box::new(e),
-                context: format!("Failed to complete poll for worker {}", worker_id),
-            })?;
-
-        if result.is_some() {
-            return Ok(());
-        }
-
-        let current_status = self.get_status(worker_id).await?;
-        Err(crate::error::Error::InvalidStateTransition {
-            from: current_status.to_string(),
-            to: "ready".to_string(),
-            reason: "Worker must be in Polling state to complete polling".to_string(),
-        })
-    }
-
-    /// Transition worker from Ready to Polling.
-    pub async fn poll(&self, worker_id: i64) -> Result<()> {
-        const TRANSITION_READY_OR_INTERRUPTED_TO_POLLING: &str = r#"
-            UPDATE pgqrs_workers
-            SET status = 'polling'
-            WHERE id = $1 AND status IN ('ready', 'polling')
-            RETURNING id
-        "#;
-        let result: Option<i64> = sqlx::query_scalar(TRANSITION_READY_OR_INTERRUPTED_TO_POLLING)
-            .bind(worker_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "TRANSITION_READY_TO_POLLING".into(),
-                source: Box::new(e),
-                context: format!("Failed to set worker {} to polling", worker_id),
-            })?;
-
-        if result.is_some() {
-            return Ok(());
-        }
-
-        let current_status = self.get_status(worker_id).await?;
-        Err(crate::error::Error::InvalidStateTransition {
-            from: current_status.to_string(),
-            to: "polling".to_string(),
-            reason: "Worker must be Ready to start polling".to_string(),
-        })
-    }
-
-    /// Transition worker from Polling to Interrupted.
-    pub async fn interrupt(&self, worker_id: i64) -> Result<()> {
-        const TRANSITION_POLLING_TO_INTERRUPTED: &str = r#"
-            UPDATE pgqrs_workers
-            SET status = 'interrupted'
-            WHERE id = $1 AND status = 'polling'
-            RETURNING id
-        "#;
-        let result: Option<i64> = sqlx::query_scalar(TRANSITION_POLLING_TO_INTERRUPTED)
-            .bind(worker_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "TRANSITION_POLLING_TO_INTERRUPTED".into(),
-                source: Box::new(e),
-                context: format!("Failed to interrupt worker {}", worker_id),
-            })?;
-
-        if result.is_some() {
-            return Ok(());
-        }
-
-        let current_status = self.get_status(worker_id).await?;
-        Err(crate::error::Error::InvalidStateTransition {
-            from: current_status.to_string(),
-            to: "interrupted".to_string(),
-            reason: "Worker must be in Polling state to be interrupted".to_string(),
-        })
-    }
-
-    /// Shutdown worker: transition from Suspended to Stopped.
-    pub async fn shutdown(&self, worker_id: i64) -> Result<()> {
-        const TRANSITION_SUSPENDED_TO_STOPPED: &str = r#"
-            UPDATE pgqrs_workers
-            SET status = 'stopped', shutdown_at = $2
-            WHERE id = $1 AND status = 'suspended'
-            RETURNING id
-        "#;
-        let now = Utc::now();
-        let result: Option<i64> = sqlx::query_scalar(TRANSITION_SUSPENDED_TO_STOPPED)
-            .bind(worker_id)
-            .bind(now)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: format!("TRANSITION_SUSPENDED_TO_STOPPED ({})", worker_id),
-                source: Box::new(e),
-                context: format!("Failed to shutdown worker {}", worker_id),
-            })?;
-
-        match result {
-            Some(_) => Ok(()),
-            None => {
-                let current_status = self.get_status(worker_id).await?;
-                Err(crate::error::Error::InvalidStateTransition {
-                    from: current_status.to_string(),
-                    to: "stopped".to_string(),
-                    reason: "Worker must be in Suspended state to shutdown".to_string(),
-                })
-            }
-        }
+        builder
     }
 }
 
@@ -724,34 +557,69 @@ impl crate::store::WorkerTable for Workers {
     }
 
     async fn suspend(&self, id: i64) -> Result<()> {
-        self.suspend(id).await
+        <Self as DialectWorkerTable>::dialect_suspend(self, id).await
     }
 
     async fn resume(&self, id: i64) -> Result<()> {
-        self.resume(id).await
+        <Self as DialectWorkerTable>::dialect_resume(self, id).await
     }
 
     async fn complete_poll(&self, id: i64) -> Result<()> {
-        self.complete_poll(id).await
+        <Self as DialectWorkerTable>::dialect_complete_poll(self, id).await
     }
 
     async fn shutdown(&self, id: i64) -> Result<()> {
-        self.shutdown(id).await
+        <Self as DialectWorkerTable>::dialect_shutdown(self, id).await
     }
 
     async fn poll(&self, id: i64) -> Result<()> {
-        self.poll(id).await
+        <Self as DialectWorkerTable>::dialect_poll(self, id).await
     }
 
     async fn interrupt(&self, id: i64) -> Result<()> {
-        self.interrupt(id).await
+        <Self as DialectWorkerTable>::dialect_interrupt(self, id).await
     }
 
     async fn heartbeat(&self, id: i64) -> Result<()> {
-        self.heartbeat(id).await
+        <Self as DialectWorkerTable>::dialect_heartbeat(self, id).await
     }
 
     async fn is_healthy(&self, id: i64, max_age: chrono::Duration) -> Result<bool> {
         self.is_healthy(id, max_age).await
+    }
+}
+
+#[async_trait]
+impl DialectWorkerTable for Workers {
+    type Dialect = PostgresDialect;
+
+    async fn execute_worker_update(&self, query: QueryBuilder) -> Result<u64> {
+        if query.sql().contains("RETURNING") {
+            let maybe_id = Self::bind_returning_query(sqlx::query_scalar(query.sql()), &query)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| crate::error::Error::QueryFailed {
+                    query: "POSTGRES_WORKER_UPDATE_RETURNING".into(),
+                    source: Box::new(e),
+                    context: "Failed to execute postgres worker returning update".into(),
+                })?;
+
+            return Ok(u64::from(maybe_id.is_some()));
+        }
+
+        let result = Self::bind_query(sqlx::query(query.sql()), &query)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| crate::error::Error::QueryFailed {
+                query: "POSTGRES_WORKER_UPDATE".into(),
+                source: Box::new(e),
+                context: "Failed to execute postgres worker update".into(),
+            })?;
+
+        Ok(result.rows_affected())
+    }
+
+    async fn query_worker_status(&self, worker_id: i64) -> Result<WorkerStatus> {
+        self.get_status(worker_id).await
     }
 }

--- a/crates/pgqrs/src/store/s3/mod.rs
+++ b/crates/pgqrs/src/store/s3/mod.rs
@@ -126,7 +126,7 @@ pub enum SyncState {
 }
 
 #[derive(Clone)]
-enum DurabilityStore {
+pub enum DurabilityStore {
     Local(snapshot::SnapshotDb),
     Durable(consistent::ConsistentDb),
 }
@@ -254,6 +254,8 @@ impl S3Store {
 
 #[async_trait]
 impl Store for S3Store {
+    type Workers = Tables<DurabilityStore>;
+
     async fn execute_raw(&self, sql: &str) -> crate::error::Result<()> {
         let sql = sql.to_string();
         self.db
@@ -317,7 +319,7 @@ impl Store for S3Store {
         &self.tables
     }
 
-    fn workers(&self) -> &dyn WorkerTable {
+    fn workers(&self) -> &Self::Workers {
         &self.tables
     }
 

--- a/crates/pgqrs/src/store/sqlite/dialect.rs
+++ b/crates/pgqrs/src/store/sqlite/dialect.rs
@@ -186,10 +186,36 @@ SET status = 'stopped',
     shutdown_at = datetime('now')
 WHERE id = ?
 "#,
+        suspend: r#"
+UPDATE pgqrs_workers
+SET status = 'suspended'
+WHERE id = $1 AND status IN ('ready', 'polling', 'interrupted')
+"#,
+        poll: r#"
+UPDATE pgqrs_workers
+SET status = 'polling'
+WHERE id = $1 AND status IN ('ready', 'polling')
+"#,
+        interrupt: r#"
+UPDATE pgqrs_workers
+SET status = 'interrupted'
+WHERE id = $1 AND status = 'polling'
+"#,
+        shutdown: r#"
+UPDATE pgqrs_workers
+SET status = 'stopped', shutdown_at = $2
+WHERE id = $1 AND status = 'suspended'
+"#,
         complete_poll: r#"
 UPDATE pgqrs_workers
 SET status = 'ready'
 WHERE id = $1 AND status = 'polling'
+"#,
+        heartbeat: r#"
+UPDATE pgqrs_workers SET heartbeat_at = $1 WHERE id = $2
+"#,
+        resume: r#"
+UPDATE pgqrs_workers SET status = 'ready' WHERE id = $1 AND status = 'suspended'
 "#,
     };
 

--- a/crates/pgqrs/src/store/sqlite/mod.rs
+++ b/crates/pgqrs/src/store/sqlite/mod.rs
@@ -24,7 +24,7 @@ use self::tables::workers::SqliteWorkerTable;
 use self::tables::workflows::SqliteWorkflowTable;
 
 #[derive(Debug, Clone)]
-pub(crate) struct SqliteTables {
+pub struct SqliteTables {
     pool: SqlitePool,
     config: Config,
     queues: Arc<SqliteQueueTable>,
@@ -200,6 +200,8 @@ impl DbTables for SqliteTables {
 
 #[async_trait]
 impl Store for SqliteStore {
+    type Workers = Tables<SerializedLock<SqliteTables>>;
+
     async fn execute_raw(&self, sql: &str) -> Result<()> {
         let sql = sql.to_string();
         self.db
@@ -256,7 +258,7 @@ impl Store for SqliteStore {
         &self.tables
     }
 
-    fn workers(&self) -> &dyn WorkerTable {
+    fn workers(&self) -> &Self::Workers {
         &self.tables
     }
 

--- a/crates/pgqrs/src/store/sqlite/tables/workers.rs
+++ b/crates/pgqrs/src/store/sqlite/tables/workers.rs
@@ -1,7 +1,9 @@
 use crate::error::Result;
 use crate::store::dialect::SqlDialect;
+use crate::store::query::{QueryBuilder, QueryParam};
 use crate::store::sqlite::dialect::SqliteDialect;
 use crate::store::sqlite::{format_sqlite_timestamp, parse_sqlite_timestamp};
+use crate::store::tables::DialectWorkerTable;
 use crate::types::{WorkerRecord, WorkerStatus};
 use async_trait::async_trait;
 use chrono::Utc;
@@ -102,24 +104,6 @@ impl SqliteWorkerTable {
             .map_err(|e| crate::error::Error::Internal { message: e })
     }
 
-    pub async fn heartbeat(&self, worker_id: i64) -> Result<()> {
-        let now = Utc::now();
-        let now_str = format_sqlite_timestamp(&now);
-
-        sqlx::query("UPDATE pgqrs_workers SET heartbeat_at = $1 WHERE id = $2")
-            .bind(now_str)
-            .bind(worker_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "UPDATE_HEARTBEAT".into(),
-                source: Box::new(e),
-                context: format!("Failed to update heartbeat for worker {}", worker_id),
-            })?;
-
-        Ok(())
-    }
-
     pub async fn is_healthy(&self, worker_id: i64, max_age: chrono::Duration) -> Result<bool> {
         let threshold = Utc::now() - max_age;
         let threshold_str = format_sqlite_timestamp(&threshold);
@@ -137,154 +121,6 @@ impl SqliteWorkerTable {
                 })?;
 
         Ok(is_healthy)
-    }
-
-    pub async fn suspend(&self, worker_id: i64) -> Result<()> {
-        let result = sqlx::query(
-            "UPDATE pgqrs_workers SET status = 'suspended' WHERE id = $1 AND status IN ('ready', 'polling', 'interrupted')", 
-        )
-        .bind(worker_id)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| crate::error::Error::QueryFailed {
-            query: "TRANSITION_TO_SUSPENDED".into(),
-            source: Box::new(e),
-            context: format!("Failed to suspend worker {}", worker_id),
-        })?;
-
-        if result.rows_affected() == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            // If status is already suspended, it's effectively a no-op / idempotent, but logic in postgres impl returns Err if not Ready.
-            // Postgres impl uses RETURNING id to check if update happened.
-            // Here we check rows_affected.
-            // If status is not ready, we error.
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "suspended".to_string(),
-                reason: "Worker must be Ready, Polling, or Interrupted to suspend".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn resume(&self, worker_id: i64) -> Result<()> {
-        let result = sqlx::query(
-            "UPDATE pgqrs_workers SET status = 'ready' WHERE id = $1 AND status = 'suspended'",
-        )
-        .bind(worker_id)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| crate::error::Error::QueryFailed {
-            query: "TRANSITION_SUSPENDED_TO_READY".into(),
-            source: Box::new(e),
-            context: format!("Failed to resume worker {}", worker_id),
-        })?;
-
-        if result.rows_affected() == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "ready".to_string(),
-                reason: "Worker must be in Suspended state to resume".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn complete_poll(&self, worker_id: i64) -> Result<()> {
-        let result = sqlx::query(SqliteDialect::WORKER.complete_poll)
-            .bind(worker_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "TRANSITION_POLLING_TO_READY".into(),
-                source: Box::new(e),
-                context: format!("Failed to complete poll for worker {}", worker_id),
-            })?;
-
-        if result.rows_affected() == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "ready".to_string(),
-                reason: "Worker must be in Polling state to complete polling".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn shutdown(&self, worker_id: i64) -> Result<()> {
-        let now = Utc::now();
-        let now_str = format_sqlite_timestamp(&now);
-
-        let result = sqlx::query("UPDATE pgqrs_workers SET status = 'stopped', shutdown_at = $2 WHERE id = $1 AND status = 'suspended'")
-            .bind(worker_id)
-            .bind(now_str)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| crate::error::Error::QueryFailed {
-                query: "TRANSITION_SUSPENDED_TO_STOPPED".into(),
-                source: Box::new(e),
-                context: format!("Failed to shutdown worker {}", worker_id),
-            })?;
-
-        if result.rows_affected() == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "stopped".to_string(),
-                reason: "Worker must be in Suspended state to shutdown".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    async fn poll(&self, worker_id: i64) -> Result<()> {
-        let result = sqlx::query(
-            "UPDATE pgqrs_workers SET status = 'polling' WHERE id = $1 AND status IN ('ready', 'polling')",
-        )
-        .bind(worker_id)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| crate::error::Error::QueryFailed {
-            query: "TRANSITION_READY_TO_POLLING".into(),
-            source: Box::new(e),
-            context: format!("Failed to set worker {} to polling", worker_id),
-        })?;
-
-        if result.rows_affected() == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "polling".to_string(),
-                reason: "Worker must be Ready to start polling".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    async fn interrupt(&self, worker_id: i64) -> Result<()> {
-        let result = sqlx::query(
-            "UPDATE pgqrs_workers SET status = 'interrupted' WHERE id = $1 AND status = 'polling'",
-        )
-        .bind(worker_id)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| crate::error::Error::QueryFailed {
-            query: "TRANSITION_POLLING_TO_INTERRUPTED".into(),
-            source: Box::new(e),
-            context: format!("Failed to interrupt worker {}", worker_id),
-        })?;
-
-        if result.rows_affected() == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "interrupted".to_string(),
-                reason: "Worker must be in Polling state to be interrupted".to_string(),
-            });
-        }
-        Ok(())
     }
 }
 
@@ -595,34 +431,70 @@ impl crate::store::WorkerTable for SqliteWorkerTable {
     }
 
     async fn suspend(&self, id: i64) -> Result<()> {
-        self.suspend(id).await
+        <Self as DialectWorkerTable>::dialect_suspend(self, id).await
     }
 
     async fn resume(&self, id: i64) -> Result<()> {
-        self.resume(id).await
+        <Self as DialectWorkerTable>::dialect_resume(self, id).await
     }
 
     async fn complete_poll(&self, id: i64) -> Result<()> {
-        self.complete_poll(id).await
+        <Self as DialectWorkerTable>::dialect_complete_poll(self, id).await
     }
 
     async fn shutdown(&self, id: i64) -> Result<()> {
-        self.shutdown(id).await
+        <Self as DialectWorkerTable>::dialect_shutdown(self, id).await
     }
 
     async fn poll(&self, id: i64) -> Result<()> {
-        self.poll(id).await
+        <Self as DialectWorkerTable>::dialect_poll(self, id).await
     }
 
     async fn interrupt(&self, id: i64) -> Result<()> {
-        self.interrupt(id).await
+        <Self as DialectWorkerTable>::dialect_interrupt(self, id).await
     }
 
     async fn heartbeat(&self, id: i64) -> Result<()> {
-        self.heartbeat(id).await
+        <Self as DialectWorkerTable>::dialect_heartbeat(self, id).await
     }
 
     async fn is_healthy(&self, id: i64, max_age: chrono::Duration) -> Result<bool> {
         self.is_healthy(id, max_age).await
+    }
+}
+
+#[async_trait]
+impl DialectWorkerTable for SqliteWorkerTable {
+    type Dialect = SqliteDialect;
+
+    async fn execute_worker_update(&self, query: QueryBuilder) -> Result<u64> {
+        let mut builder = sqlx::query(query.sql());
+        for param in query.params() {
+            builder = match param {
+                QueryParam::I64(value) => builder.bind(*value),
+                QueryParam::I32(value) => builder.bind(*value),
+                QueryParam::String(value) => builder.bind(value),
+                QueryParam::Json(value) => builder.bind(value.to_string()),
+                QueryParam::DateTime(value) => {
+                    builder.bind(value.map(|dt| format_sqlite_timestamp(&dt)))
+                }
+            };
+        }
+
+        let result =
+            builder
+                .execute(&self.pool)
+                .await
+                .map_err(|e| crate::error::Error::QueryFailed {
+                    query: "SQLITE_WORKER_UPDATE".into(),
+                    source: Box::new(e),
+                    context: "Failed to execute sqlite worker update".into(),
+                })?;
+
+        Ok(result.rows_affected())
+    }
+
+    async fn query_worker_status(&self, worker_id: i64) -> Result<WorkerStatus> {
+        self.get_status(worker_id).await
     }
 }

--- a/crates/pgqrs/src/store/tables/mod.rs
+++ b/crates/pgqrs/src/store/tables/mod.rs
@@ -3,3 +3,6 @@ pub(crate) mod step;
 
 pub use lock::Tables;
 pub(crate) use step::DialectStepTable;
+
+pub(crate) mod workers;
+pub(crate) use workers::DialectWorkerTable;

--- a/crates/pgqrs/src/store/tables/workers.rs
+++ b/crates/pgqrs/src/store/tables/workers.rs
@@ -1,0 +1,123 @@
+use crate::error::Result;
+use crate::store::dialect::SqlDialect;
+use crate::store::query::QueryBuilder;
+use crate::types::WorkerStatus;
+use async_trait::async_trait;
+use chrono::Utc;
+
+#[async_trait]
+pub(crate) trait DialectWorkerTable: crate::store::WorkerTable + Sync {
+    type Dialect: SqlDialect;
+
+    async fn execute_worker_update(&self, query: QueryBuilder) -> Result<u64>;
+    async fn query_worker_status(&self, worker_id: i64) -> Result<WorkerStatus>;
+
+    async fn ensure_shutdown_allowed(&self, _worker_id: i64) -> Result<()> {
+        Ok(())
+    }
+
+    async fn dialect_heartbeat(&self, worker_id: i64) -> Result<()> {
+        let now = Utc::now();
+
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.heartbeat)
+                .bind_datetime(Some(now))
+                .bind_i64(worker_id),
+            worker_id,
+            None,
+        )
+        .await
+    }
+
+    async fn dialect_suspend(&self, worker_id: i64) -> Result<()> {
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.suspend).bind_i64(worker_id),
+            worker_id,
+            Some((
+                "suspended",
+                "Worker must be Ready, Polling, or Interrupted to suspend",
+            )),
+        )
+        .await
+    }
+
+    async fn dialect_complete_poll(&self, worker_id: i64) -> Result<()> {
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.complete_poll).bind_i64(worker_id),
+            worker_id,
+            Some((
+                "ready",
+                "Worker must be in Polling state to complete polling",
+            )),
+        )
+        .await
+    }
+
+    async fn dialect_resume(&self, worker_id: i64) -> Result<()> {
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.resume).bind_i64(worker_id),
+            worker_id,
+            Some(("ready", "Worker must be in Suspended state to resume")),
+        )
+        .await
+    }
+
+    async fn dialect_poll(&self, worker_id: i64) -> Result<()> {
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.poll).bind_i64(worker_id),
+            worker_id,
+            Some(("polling", "Worker must be Ready to start polling")),
+        )
+        .await
+    }
+
+    async fn dialect_interrupt(&self, worker_id: i64) -> Result<()> {
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.interrupt).bind_i64(worker_id),
+            worker_id,
+            Some((
+                "interrupted",
+                "Worker must be in Polling state to be interrupted",
+            )),
+        )
+        .await
+    }
+
+    async fn dialect_shutdown(&self, worker_id: i64) -> Result<()> {
+        self.ensure_shutdown_allowed(worker_id).await?;
+        let now = Utc::now();
+
+        self.ensure_transition(
+            QueryBuilder::new(Self::Dialect::WORKER.shutdown)
+                .bind_i64(worker_id)
+                .bind_datetime(Some(now)),
+            worker_id,
+            Some(("stopped", "Worker must be in Suspended state to shutdown")),
+        )
+        .await
+    }
+
+    async fn ensure_transition(
+        &self,
+        query: QueryBuilder,
+        worker_id: i64,
+        invalid_transition: Option<(&'static str, &'static str)>,
+    ) -> Result<()> {
+        let count = self.execute_worker_update(query).await?;
+
+        if count > 0 {
+            return Ok(());
+        }
+
+        if let Some((to, reason)) = invalid_transition {
+            let current_status = self.query_worker_status(worker_id).await?;
+            return Err(crate::error::Error::InvalidStateTransition {
+                from: current_status.to_string(),
+                to: to.to_string(),
+                reason: reason.to_string(),
+            });
+        }
+
+        Err(crate::error::Error::WorkerNotFound { id: worker_id })
+    }
+}

--- a/crates/pgqrs/src/store/turso/dialect.rs
+++ b/crates/pgqrs/src/store/turso/dialect.rs
@@ -184,10 +184,36 @@ SET status = 'stopped',
     shutdown_at = datetime('now')
 WHERE id = ?
 "#,
+        suspend: r#"
+UPDATE pgqrs_workers
+SET status = 'suspended'
+WHERE id = ? AND status IN ('ready', 'polling', 'interrupted')
+"#,
+        poll: r#"
+UPDATE pgqrs_workers
+SET status = 'polling'
+WHERE id = ? AND status IN ('ready', 'polling')
+"#,
+        interrupt: r#"
+UPDATE pgqrs_workers
+SET status = 'interrupted'
+WHERE id = ? AND status = 'polling'
+"#,
+        shutdown: r#"
+UPDATE pgqrs_workers
+SET status = 'stopped', shutdown_at = ?2
+WHERE id = ?1 AND status = 'suspended'
+"#,
         complete_poll: r#"
 UPDATE pgqrs_workers
 SET status = 'ready'
 WHERE id = ? AND status = 'polling'
+"#,
+        heartbeat: r#"
+UPDATE pgqrs_workers SET heartbeat_at = ? WHERE id = ?
+"#,
+        resume: r#"
+UPDATE pgqrs_workers SET status = 'ready' WHERE id = ? AND status = 'suspended'
 "#,
     };
 

--- a/crates/pgqrs/src/store/turso/mod.rs
+++ b/crates/pgqrs/src/store/turso/mod.rs
@@ -25,7 +25,7 @@ use self::tables::workers::TursoWorkerTable;
 use self::tables::workflows::TursoWorkflowTable;
 
 #[derive(Debug, Clone)]
-pub(crate) struct TursoTables {
+pub struct TursoTables {
     db: Arc<Database>,
     config: Config,
     queues: Arc<TursoQueueTable>,
@@ -704,6 +704,8 @@ impl DbTables for TursoTables {
 
 #[async_trait]
 impl Store for TursoStore {
+    type Workers = Tables<SerializedLock<TursoTables>>;
+
     async fn execute_raw(&self, sql: &str) -> Result<()> {
         let sql = sql.to_string();
         self.db
@@ -760,7 +762,7 @@ impl Store for TursoStore {
         &self.tables
     }
 
-    fn workers(&self) -> &dyn WorkerTable {
+    fn workers(&self) -> &Self::Workers {
         &self.tables
     }
 

--- a/crates/pgqrs/src/store/turso/tables/workers.rs
+++ b/crates/pgqrs/src/store/turso/tables/workers.rs
@@ -1,5 +1,7 @@
 use crate::error::Result;
 use crate::store::dialect::SqlDialect;
+use crate::store::query::{QueryBuilder, QueryParam};
+use crate::store::tables::DialectWorkerTable;
 use crate::store::turso::dialect::TursoDialect;
 use crate::store::turso::{format_turso_timestamp, parse_turso_timestamp};
 use crate::types::{WorkerRecord, WorkerStatus};
@@ -98,19 +100,6 @@ impl TursoWorkerTable {
             .map_err(|e| crate::error::Error::Internal { message: e })
     }
 
-    pub async fn heartbeat(&self, worker_id: i64) -> Result<()> {
-        let now = Utc::now();
-        let now_str = format_turso_timestamp(&now);
-
-        crate::store::turso::query("UPDATE pgqrs_workers SET heartbeat_at = ? WHERE id = ?")
-            .bind(now_str)
-            .bind(worker_id)
-            .execute_once(&self.db)
-            .await?;
-
-        Ok(())
-    }
-
     pub async fn is_healthy(&self, worker_id: i64, max_age: chrono::Duration) -> Result<bool> {
         let threshold = Utc::now() - max_age;
         let threshold_str = format_turso_timestamp(&threshold);
@@ -124,134 +113,6 @@ impl TursoWorkerTable {
         .await?;
 
         Ok(is_healthy)
-    }
-
-    pub async fn suspend(&self, worker_id: i64) -> Result<()> {
-        let count = crate::store::turso::query(
-            "UPDATE pgqrs_workers SET status = 'suspended' WHERE id = ? AND status IN ('ready', 'polling', 'interrupted')", 
-        )
-        .bind(worker_id)
-        .execute_once(&self.db)
-        .await?;
-
-        if count == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "suspended".to_string(),
-                reason: "Worker must be Ready, Polling, or Interrupted to suspend".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn resume(&self, worker_id: i64) -> Result<()> {
-        let count = crate::store::turso::query(
-            "UPDATE pgqrs_workers SET status = 'ready' WHERE id = ? AND status = 'suspended'",
-        )
-        .bind(worker_id)
-        .execute_once(&self.db)
-        .await?;
-
-        if count == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "ready".to_string(),
-                reason: "Worker must be in Suspended state to resume".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn complete_poll(&self, worker_id: i64) -> Result<()> {
-        let count = crate::store::turso::query(TursoDialect::WORKER.complete_poll)
-            .bind(worker_id)
-            .execute_once(&self.db)
-            .await?;
-
-        if count == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "ready".to_string(),
-                reason: "Worker must be in Polling state to complete polling".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn poll(&self, worker_id: i64) -> Result<()> {
-        let count = crate::store::turso::query(
-            "UPDATE pgqrs_workers SET status = 'polling' WHERE id = ? AND status IN ('ready', 'polling')",
-        )
-        .bind(worker_id)
-        .execute_once(&self.db)
-        .await?;
-
-        if count == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "polling".to_string(),
-                reason: "Worker must be Ready to start polling".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn interrupt(&self, worker_id: i64) -> Result<()> {
-        let count = crate::store::turso::query(
-            "UPDATE pgqrs_workers SET status = 'interrupted' WHERE id = ? AND status = 'polling'",
-        )
-        .bind(worker_id)
-        .execute_once(&self.db)
-        .await?;
-
-        if count == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "interrupted".to_string(),
-                reason: "Worker must be in Polling state to be interrupted".to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn shutdown(&self, worker_id: i64) -> Result<()> {
-        let held_count: i64 = crate::store::turso::query_scalar(
-            "SELECT COUNT(*) FROM pgqrs_messages WHERE consumer_worker_id = ? AND archived_at IS NULL",
-        )
-        .bind(worker_id)
-        .fetch_one(&self.db)
-        .await?;
-
-        if held_count > 0 {
-            return Err(crate::error::Error::WorkerHasPendingMessages {
-                reason: format!("Worker has {} pending messages", held_count),
-                count: held_count as u64,
-            });
-        }
-
-        let now = Utc::now();
-        let now_str = format_turso_timestamp(&now);
-
-        let count = crate::store::turso::query("UPDATE pgqrs_workers SET status = 'stopped', shutdown_at = ? WHERE id = ? AND status = 'suspended'")
-            .bind(now_str)
-            .bind(worker_id)
-            .execute_once(&self.db)
-            .await?;
-
-        if count == 0 {
-            let current_status = self.get_status(worker_id).await?;
-            return Err(crate::error::Error::InvalidStateTransition {
-                from: current_status.to_string(),
-                to: "stopped".to_string(),
-                reason: "Worker must be in Suspended state to shutdown".to_string(),
-            });
-        }
-        Ok(())
     }
 }
 
@@ -502,34 +363,80 @@ impl crate::store::WorkerTable for TursoWorkerTable {
     }
 
     async fn suspend(&self, id: i64) -> Result<()> {
-        self.suspend(id).await
+        <Self as DialectWorkerTable>::dialect_suspend(self, id).await
     }
 
     async fn resume(&self, id: i64) -> Result<()> {
-        self.resume(id).await
+        <Self as DialectWorkerTable>::dialect_resume(self, id).await
     }
 
     async fn complete_poll(&self, id: i64) -> Result<()> {
-        self.complete_poll(id).await
+        <Self as DialectWorkerTable>::dialect_complete_poll(self, id).await
     }
 
     async fn shutdown(&self, id: i64) -> Result<()> {
-        self.shutdown(id).await
+        <Self as DialectWorkerTable>::dialect_shutdown(self, id).await
     }
 
     async fn poll(&self, id: i64) -> Result<()> {
-        self.poll(id).await
+        <Self as DialectWorkerTable>::dialect_poll(self, id).await
     }
 
     async fn interrupt(&self, id: i64) -> Result<()> {
-        self.interrupt(id).await
+        <Self as DialectWorkerTable>::dialect_interrupt(self, id).await
     }
 
     async fn heartbeat(&self, id: i64) -> Result<()> {
-        self.heartbeat(id).await
+        <Self as DialectWorkerTable>::dialect_heartbeat(self, id).await
     }
 
     async fn is_healthy(&self, id: i64, max_age: chrono::Duration) -> Result<bool> {
         self.is_healthy(id, max_age).await
+    }
+}
+
+#[async_trait]
+impl DialectWorkerTable for TursoWorkerTable {
+    type Dialect = TursoDialect;
+
+    async fn execute_worker_update(&self, query: QueryBuilder) -> Result<u64> {
+        let mut builder = crate::store::turso::query(query.sql());
+        for param in query.params() {
+            let value = match param {
+                QueryParam::I64(value) => turso::Value::Integer(*value),
+                QueryParam::I32(value) => turso::Value::Integer((*value).into()),
+                QueryParam::String(value) => turso::Value::Text(value.clone()),
+                QueryParam::Json(value) => turso::Value::Text(value.to_string()),
+                QueryParam::DateTime(value) => match value {
+                    Some(dt) => turso::Value::Text(format_turso_timestamp(dt)),
+                    None => turso::Value::Null,
+                },
+            };
+            builder = builder.bind(value);
+        }
+
+        builder.execute_once(&self.db).await
+    }
+
+    async fn query_worker_status(&self, worker_id: i64) -> Result<WorkerStatus> {
+        self.get_status(worker_id).await
+    }
+
+    async fn ensure_shutdown_allowed(&self, worker_id: i64) -> Result<()> {
+        let held_count: i64 = crate::store::turso::query_scalar(
+            "SELECT COUNT(*) FROM pgqrs_messages WHERE consumer_worker_id = ? AND archived_at IS NULL",
+        )
+        .bind(worker_id)
+        .fetch_one(&self.db)
+        .await?;
+
+        if held_count > 0 {
+            return Err(crate::error::Error::WorkerHasPendingMessages {
+                reason: format!("Worker has {} pending messages", held_count),
+                count: held_count as u64,
+            });
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- move worker lifecycle transitions into a shared dialect helper for worker tables
- add typed Store workers access so worker table callers can use concrete associated worker types
- remove duplicated backend transition code from postgres, sqlite, and turso worker tables while preserving Turso shutdown validation

## Testing
- cargo fmt --all --check
- cargo check -p pgqrs --no-default-features --features sqlite
- cargo check -p pgqrs --no-default-features --features turso
- cargo check -p pgqrs --no-default-features --features postgres